### PR TITLE
Terminating app due to uncaught exception 'NSGenericException'

### DIFF
--- a/RSSelectionMenu/RSSelectionMenu/Source/RSSelectionMenuController.swift
+++ b/RSSelectionMenu/RSSelectionMenu/Source/RSSelectionMenuController.swift
@@ -368,6 +368,10 @@ extension RSSelectionMenu {
         else if case let .Actionsheet(title, action, height) = with {
             tobePresentController = getAlertViewController(style: .actionSheet, title: title, action: action, height: height)
             tobePresentController.setValue(self, forKey: contentViewController)
+            
+            tobePresentController.popoverPresentationController?.sourceView = self.view
+            tobePresentController.popoverPresentationController?.permittedArrowDirections = UIPopoverArrowDirection()
+            tobePresentController.popoverPresentationController?.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
         }
         
         from.present(tobePresentController, animated: true, completion: nil)


### PR DESCRIPTION
Hi @rushisangani, Thanks for providing a great library for values selection.

When I am trying to run `ActionSheet` example of library on iPAD, I am getting below error:

`
RSSelectionMenuExample[31899:304616] *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Your application has presented a UIAlertController (<UIAlertController: 0x7faaac03a400>) of style UIAlertControllerStyleActionSheet. The modalPresentationStyle of a UIAlertController with this style is UIModalPresentationPopover. You must provide location information for this popover through the alert controller's popoverPresentationController. You must provide either a sourceView and sourceRect or a barButtonItem.  If this information is not known when you present the alert controller, you may provide it in the UIPopoverPresentationControllerDelegate method -prepareForPopoverPresentation.'
`

Post searching the same on Google, I found below post for the solution:

[Stack Overflow: Reference](https://stackoverflow.com/questions/28089898/actionsheet-not-working-ipad)

Post integrating fix it is working on both iPhone & iPAD. 

Can you please merge the raised PR. Please let me know incase any additional information is required too.

Thanks
</ Pranav >