### PR TITLE
Adding UIAlertAction for closing the action sheet when action exists

### DIFF
--- a/RSSelectionMenu/RSSelectionMenu/Source/RSSelectionMenuController.swift
+++ b/RSSelectionMenu/RSSelectionMenu/Source/RSSelectionMenuController.swift
@@ -435,7 +435,7 @@ extension RSSelectionMenu {
         }
         
         // add done action
-        if (tableView?.selectionStyle == .multiple || !self.dismissAutomatically)  {
+        if (tableView?.selectionStyle == .multiple || !self.dismissAutomatically || style == .actionSheet)  {
             alertController.addAction(doneAction)
         }
         


### PR DESCRIPTION
The user cannot close the action sheet without selecting any item if the dismissAutomatically = true or selectionStyle == .multiple. So this change will add a close action even in single selection type.